### PR TITLE
Misc Scene3D performance improvements

### DIFF
--- a/RSDKv5/RSDK/Graphics/Scene3D.cpp
+++ b/RSDKv5/RSDK/Graphics/Scene3D.cpp
@@ -2,6 +2,10 @@
 
 using namespace RSDK;
 
+#if RETRO_PLATFORM == RETRO_WIIU
+#include <algorithm>
+#endif
+
 #if RETRO_REV0U
 #include "Legacy/Scene3DLegacy.cpp"
 #endif
@@ -176,8 +180,10 @@ void RSDK::SetIdentityMatrix(Matrix *matrix)
 void RSDK::MatrixMultiply(Matrix *dest, Matrix *matrixA, Matrix *matrixB)
 {
     int32 result[4][4];
+#if RETRO_PLATFORM != RETRO_WIIU
+    // Every element will be overwritten anyway, so memset is unneeded here.
     memset(result, 0, 4 * 4 * sizeof(int32));
-
+#endif
     for (int32 i = 0; i < 0x10; ++i) {
         uint32 rowA        = i / 4;
         uint32 rowB        = i % 4;
@@ -879,6 +885,10 @@ void RSDK::Draw3DScene(uint16 sceneID)
 
         Scene3DFace *a = scn->faceBuffer;
 
+#if RETRO_PLATFORM == RETRO_WIIU
+        // Use the faster std::sort instead
+        std::sort(a, a + scn->faceCount, [](const Scene3DFace &a, const Scene3DFace &b) { return a.depth > b.depth; });
+#else
         int i, j;
         Scene3DFace temp;
 
@@ -893,7 +903,7 @@ void RSDK::Draw3DScene(uint16 sceneID)
             }
             a[j+1] = temp;
         }
-
+#endif
         // Finally, display the faces.
 
         uint8 *vertCnt = scn->faceVertCounts;

--- a/RSDKv5/RSDK/Graphics/Scene3D.cpp
+++ b/RSDKv5/RSDK/Graphics/Scene3D.cpp
@@ -886,8 +886,8 @@ void RSDK::Draw3DScene(uint16 sceneID)
         Scene3DFace *a = scn->faceBuffer;
 
 #if RETRO_PLATFORM == RETRO_WIIU
-        // Use the faster std::sort instead
-        std::sort(a, a + scn->faceCount, [](const Scene3DFace &a, const Scene3DFace &b) { return a.depth > b.depth; });
+        // Use the faster std::stable_sort instead
+        std::stable_sort(a, a + scn->faceCount, [](const Scene3DFace &a, const Scene3DFace &b) { return a.depth > b.depth; });
 #else
         int i, j;
         Scene3DFace temp;

--- a/RSDKv5/RSDK/Graphics/Scene3D.hpp
+++ b/RSDKv5/RSDK/Graphics/Scene3D.hpp
@@ -154,10 +154,16 @@ inline void Prepare3DScene(uint16 sceneID)
         scn->vertexCount = 0;
         scn->faceCount   = 0;
 
+/**
+ * These memsets are useless since we zero'd the vertex/face counts, so just ignore them.
+ * Since newlib doesn't have a fast memset implementation for the PowerPC 750, the performance gains are huge.
+ */
+#if RETRO_PLATFORM != RETRO_WIIU
         memset(scn->vertices, 0, sizeof(Scene3DVertex) * scn->vertLimit);
         memset(scn->normals, 0, sizeof(Scene3DVertex) * scn->vertLimit);
         memset(scn->faceVertCounts, 0, sizeof(uint8) * scn->vertLimit);
         memset(scn->faceBuffer, 0, sizeof(Scene3DFace) * scn->vertLimit);
+#endif
     }
 }
 


### PR DESCRIPTION
Backport some generic optimisations I've used in my Wii port.
**/!\ Not tested** as I don't have a Wii U, but I'm pretty confident that this could be enough to make the special stages run at full speed.

* Remove unneeded, slow memset(0) from the code: newlib doesn't have a fast, assembly optimised version of common standard functions for the PowerPC 750, so the performance gains are huge.
* Prefer the faster std::sort for sorting faces