### PR TITLE
Fix 1080p shimmer by running at 4x (960) instead of 4.5x (1080) internally

### DIFF
--- a/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/SDL2/SDL2RenderDevice.cpp
@@ -44,7 +44,8 @@ bool RenderDevice::Init()
     videoSettings.windowHeight = 1080;
     flags |= SDL_WINDOW_FULLSCREEN;
 #elif RETRO_PLATFORM == RETRO_WIIU
-    flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+    videoSettings.windowWidth  = 1708;
+    videoSettings.windowHeight = 960;
 #endif
 
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");


### PR DESCRIPTION
Fixes #2

As explained in that issue, Mania already looks perfectly fine when the console is configured to 480p (2x native) or 720p (3x native), but has shimmering artifacts at 1080i/p (4.5x) because it is just nearest-neighbor scaling directly to the native output resolution. This also affects the GamePad since it's receiving a downscale of the TV image (1x -> 4.5x -> 2x).

Instead of running at the fullscreen native resolution (480/720/1080), this PR sets a window size of 1708\*960. This is 4x the original 240p image, preventing the shimmering artifacts. It also downscales back to 720/480 cleanly, so users who were already running at 480/720 won't notice any difference.

Thanks to @GaryOderNichts for directing me to this fix; Gary explained and I typed.