### PR TITLE
feat: Wii U: get username from user's Mii name

### DIFF
--- a/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
+++ b/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
@@ -38,10 +38,10 @@ bool32 DummyUserStorage::GetUsername(String *name)
     std::array<int16_t, nn::act::MiiNameSize> miiName;
 
     nn::act::Initialize();
-    const nn::Result result = nn::act::GetMiiName(miiName);
+    const nn::Result result = nn::act::GetMiiName(miiName.data());
 
     if (result.IsSuccess()) {
-        std:::array<char, nn::act::MiiNameSize + 1> userName;
+        std::array<char, nn::act::MiiNameSize + 1> userName;
         for (std::size_t i = 0; i < miiName.size(); ++i) {
             userName[i] = static_cast<char>(miiName[i]);
         }

--- a/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
+++ b/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
@@ -59,7 +59,8 @@ bool32 DummyUserStorage::GetUsername(String *name)
     if (strlen(customSettings.username) > 0)
         InitString(name, customSettings.username, 0);
     else
-#endif
+        InitString(name, "IntegerGeorge802", 0);
+#else
     InitString(name, "IntegerGeorge802", 0);
 #endif
     return true;

--- a/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
+++ b/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
@@ -1,4 +1,9 @@
 #if RETRO_REV02
+
+#if RETRO_PLATFORM == RETRO_WIIU
+#include <nn/act.h> 
+#endif
+
 int32 DummyUserStorage::TryAuth()
 {
     if (authStatus == STATUS_CONTINUE) {
@@ -28,11 +33,27 @@ int32 DummyUserStorage::TryInitStorage()
 }
 bool32 DummyUserStorage::GetUsername(String *name)
 {
-#if !RETRO_USE_ORIGINAL_CODE
-    if (strlen(customSettings.username) > 0)
-        InitString(name, customSettings.username, 0);
-    else
+#if !RETRO_USE_ORIGINAL_CODE && RETRO_PLATFORM == RETRO_WIIU
+    int16_t miiName[256];
+
+    nn::act::Initialize();
+    nn::Result result = nn::act::GetMiiName(miiName);
+
+    if (result.IsSuccess()) {
+        char userName[256];
+        for (int i = 0; i < sizeof(miiName) / sizeof(miiName[0]); ++i) {
+            userName[i] = static_cast<char>(miiName[i]);
+        }
+        userName[sizeof(miiName) / sizeof(miiName[0]) - 1] = '\0';
+
+        InitString(name, userName, 0);
+    }
+    else {
         InitString(name, "IntegerGeorge802", 0);
+    }
+
+    nn::act::Finalize();
+
 #else
     InitString(name, "IntegerGeorge802", 0);
 #endif

--- a/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
+++ b/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
@@ -1,6 +1,7 @@
 #if RETRO_REV02
 
 #if RETRO_PLATFORM == RETRO_WIIU
+#include <array>
 #include <nn/act.h> 
 #endif
 
@@ -33,28 +34,32 @@ int32 DummyUserStorage::TryInitStorage()
 }
 bool32 DummyUserStorage::GetUsername(String *name)
 {
-#if !RETRO_USE_ORIGINAL_CODE && RETRO_PLATFORM == RETRO_WIIU
-    int16_t miiName[256];
+#if RETRO_PLATFORM == RETRO_WIIU
+    std::array<int16_t, nn::act::MiiNameSize> miiName;
 
     nn::act::Initialize();
-    nn::Result result = nn::act::GetMiiName(miiName);
+    const nn::Result result = nn::act::GetMiiName(miiName);
 
     if (result.IsSuccess()) {
-        char userName[256];
-        for (int i = 0; i < sizeof(miiName) / sizeof(miiName[0]); ++i) {
+        std:::array<char, nn::act::MiiNameSize + 1> userName;
+        for (std::size_t i = 0; i < miiName.size(); ++i) {
             userName[i] = static_cast<char>(miiName[i]);
         }
-        userName[sizeof(miiName) / sizeof(miiName[0]) - 1] = '\0';
+        userName.back() = '\0';
 
-        InitString(name, userName, 0);
+        InitString(name, userName.data(), 0);
     }
     else {
         InitString(name, "IntegerGeorge802", 0);
     }
 
     nn::act::Finalize();
-
 #else
+#if !RETRO_USE_ORIGINAL_CODE
+    if (strlen(customSettings.username) > 0)
+        InitString(name, customSettings.username, 0);
+    else
+#endif
     InitString(name, "IntegerGeorge802", 0);
 #endif
     return true;

--- a/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
+++ b/RSDKv5/RSDK/User/Dummy/DummyStorage.cpp
@@ -63,6 +63,7 @@ bool32 DummyUserStorage::GetUsername(String *name)
 #else
     InitString(name, "IntegerGeorge802", 0);
 #endif
+#endif
     return true;
 }
 void DummyUserStorage::ClearPrerollErrors()


### PR DESCRIPTION
This PR rewrites DummyStorage's GetUsername function to retrieve the current user's Mii name on Wii U. As it stands, this replaces the need to manually set a custom username; which I found to be cumbersome, but if this is undesirable, I could rework this to allow for both options. For this reason, I haven't removed that field from Settings.ini. I would greatly appreciate input on this. Thanks!

![image](https://github.com/Clownacy/RSDKv5-Decompilation-Wii-U/assets/64166386/121f2097-7ae8-4c8e-8e69-4d092254d108)
